### PR TITLE
Use fixed version for this flex-types thing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@angular/common": "^5.2.0",
     "@angular/compiler": "^5.2.0",
     "@angular/core": "^5.2.0",
-    "@angular/flex-layout": "^2.0.0-beta.12",
+    "@angular/flex-layout": "2.0.0-beta.12",
     "@angular/forms": "^5.2.0",
     "@angular/http": "^5.2.0",
     "@angular/material": "^5.1.0",


### PR DESCRIPTION
Ignore this if you want.  This was the one issue I had getting the project running on my machine.

`npm install` installed some not-great version of `@angular/flex-layout`, so the project wouldn't compile.  This fixes that.

